### PR TITLE
Pass through plaid's onExit parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class ReactPlaid extends Component {
 
   handleExit = () => {
     this.open = false;
-    this.props.onExit();
+    this.props.onExit.apply(this, arguments);
   };
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class ReactPlaid extends Component {
 
   handleExit = (...args) => {
     this.open = false;
-    this.props.onExit(...args)
+    this.props.onExit(...args);
   };
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -85,9 +85,9 @@ class ReactPlaid extends Component {
     this.props.onSuccess(publicToken, metaData);
   };
 
-  handleExit = () => {
+  handleExit = (...args) => {
     this.open = false;
-    this.props.onExit.apply(this, arguments);
+    this.props.onExit(...args)
   };
 
   render() {


### PR DESCRIPTION
Small change to pass through the [arguments](https://plaid.com/docs/api/#onexit-callback) for `onExit` instead of dropping them